### PR TITLE
Reproduce number formatting bug

### DIFF
--- a/src/__tests__/fixtures/trim-trailing-zeros.compact.css
+++ b/src/__tests__/fixtures/trim-trailing-zeros.compact.css
@@ -1,1 +1,1 @@
-div { top: 50px; }
+div { top: 50px; bottom: 1.0505px; }

--- a/src/__tests__/fixtures/trim-trailing-zeros.compressed.css
+++ b/src/__tests__/fixtures/trim-trailing-zeros.compressed.css
@@ -1,1 +1,1 @@
-div{top:50.000px}
+div{top:50.000px;bottom:1.0505px}

--- a/src/__tests__/fixtures/trim-trailing-zeros.expanded.css
+++ b/src/__tests__/fixtures/trim-trailing-zeros.expanded.css
@@ -1,3 +1,4 @@
 div {
     top: 50px;
+    bottom: 1.0505px;
 }

--- a/src/__tests__/fixtures/trim-trailing-zeros.fixture.css
+++ b/src/__tests__/fixtures/trim-trailing-zeros.fixture.css
@@ -1,3 +1,5 @@
 div {
     top: 50.000px;
+    bottom: 1.0505px;
+    color: rgba(255, 255, 255, 0.5050);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -323,8 +323,8 @@ function applyTransformFeatures (rule, opts) {
         rule.value = rule.value.replace(/(\s|^)(\.\d+)/g, '$10$2');
     }
     if (opts.trimTrailingZeros === true) {
-        rule.value = rule.value.replace(/(\d+)(\.[0-9]*[1-9]+)(0+)/g, '$1$2');
-        rule.value = rule.value.replace(/(\d+)(\.0+)/g, '$1');
+        rule.value = rule.value.replace(/(\d+)(\.[0-9]*[1-9])0*(.*)/g, '$1$2$3');
+        rule.value = rule.value.replace(/(?=.*?\.)(.*[1-9])(?!.*?\.)(0*)(.*)/, '$1$3');
     }
 }
 


### PR DESCRIPTION
Firstly, thank you for this project 😸 .

This PR illustrates a small bug when handling fractional numbers. The value `1.05` is being turned into `15`. I plan on digging in and proposing a patch when I get some time after work so I will keep you updated.

##### Input

```css
.foo {
  transform: scale(1.05);
}
```

##### Output

```css
.foo {
  transform: scale(15);
}
```

##### Test output

```
❯ npm t

> perfectionist@2.3.0 pretest /Users/johnotander/code/perfectionist
> eslint src


> perfectionist@2.3.0 test /Users/johnotander/code/perfectionist
> ava src/__tests__/


   39 passed
   3 failed


   1. api › can be used as a postcss plugin
   should be consumed   
  t.deepEqual(css, 'h1 {\n    color: #fff;\n}\n.foo {\n    transform: scale(1.05);\n}\n', 'should be consumed')
              |                                                                                                
              "h1 {\n    color: #fff;\n}\n\n.foo {\n    transform: scale(15);\n}\n"                            
  
      "h1 {/n    color: #fff;/n}/n/n.foo {/n    transform: scale(15);/n}/n"
        api.js:9:11
        process._tickCallback (internal/process/next_tick.js:103:7)


   2. api › can be used as a postcss plugin (2)
   should be consumed   
  t.deepEqual(css, 'h1 {\n    color: #fff;\n}\n.foo {\n    transform: scale(1.05);\n}\n', 'should be consumed')
              |                                                                                                
              "h1 {\n    color: #fff;\n}\n\n.foo {\n    transform: scale(15);\n}\n"                            
  
      "h1 {/n    color: #fff;/n}/n/n.foo {/n    transform: scale(15);/n}/n"
        api.js:9:11
        process._tickCallback (internal/process/next_tick.js:103:7)


   3. api › can be used as a postcss plugin (3)
   should be consumed   
  t.deepEqual(css, 'h1 {\n    color: #fff;\n}\n.foo {\n    transform: scale(1.05);\n}\n', 'should be consumed')
              |                                                                                                
              "h1 {\n    color: #fff;\n}\n\n.foo {\n    transform: scale(15);\n}\n"                            
  
      "h1 {/n    color: #fff;/n}/n/n.foo {/n    transform: scale(15);/n}/n"
        api.js:9:11
        process._tickCallback (internal/process/next_tick.js:103:7)
npm ERR! Test failed.  See above for more details.
```

***

Related to tachyons-css/tachyons#261